### PR TITLE
手数料計算のJSを機能させる

### DIFF
--- a/app/assets/javascripts/slider.js
+++ b/app/assets/javascripts/slider.js
@@ -1,4 +1,4 @@
-$(document).on('turbolinks:load', function(){
+$(function(){
   $('.slick').slick({
     autoplay: true,
     dots: true,

--- a/app/views/partial/_sell-btn.html.haml
+++ b/app/views/partial/_sell-btn.html.haml
@@ -1,3 +1,3 @@
-= link_to new_item_path, class: 'sell-btn' do
+= link_to new_item_path, data: {"turbolinks" => false}, class: 'sell-btn' do
   .sell-btn__head 出品
   %i.fas.fa-camera


### PR DESCRIPTION
#WHAT
1. スリックからターボリンクスの記載を削除
1. 出品ページへ遷移する際に、ターボリンクスを作動させない

#WHY
手数料計算のJSを機能させるため