### PR TITLE
商品購入確認画面の写真の表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -65,6 +65,7 @@ class ItemsController < ApplicationController
   end
 
   def buy_confirmation
+    @item = Item.find(params[:id])
     if @card.blank?
       #登録された情報がない場合にカード登録画面に移動
       redirect_to controller: "cards", action: "new"

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -9,7 +9,7 @@
     .item
       .item__box
         .item__box__image
-          = image_tag "sample.jpg", size: "80x80"
+          = image_tag @item.photos.first.image.url, size: "80x80"
         .item__box__content
           .item__name
             = @item.name


### PR DESCRIPTION
#WHAT
商品購入確認画面の写真を、サンプル画像からデータベースの写真に変更

#WHY
どのアイテムでも同じ写真を表示していたため